### PR TITLE
Add function to make git clone less tedious

### DIFF
--- a/commands/basic_bash_cmds.sh
+++ b/commands/basic_bash_cmds.sh
@@ -40,3 +40,10 @@ alias v="code $1"
 
 #activate virtual environment
 alias act="source $1/bin/activate"
+
+# Search for text within the current directory.
+qt() {
+    grep -ir --color=always "$*" --exclude-dir=".git" --exclude-dir="node_modules" . | less -RX
+    #     │└─ search all files under each directory, recursively
+    #     └─ ignore case
+}

--- a/commands/git_cmds.sh
+++ b/commands/git_cmds.sh
@@ -87,3 +87,10 @@ function gacpb() {
         echo -e "\n Quit."
     fi
 }
+
+# Making git clone less tedious
+# Instead of `git clone git@github.com:org/repo.git` do:
+# `clone org repo` or `clone username repo`
+clone() {
+    git clone git@github.com:$1/$2.git
+}


### PR DESCRIPTION
Instead of `git clone git@github.com:org/repo.git` do:
`clone org repo` or `clone username repo`